### PR TITLE
Better config printing

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,9 +15,9 @@ jobs:
         with:
           go-version: 1.22
           cache: false
-      - uses: golangci/golangci-lint-action@v6
+      - uses: golangci/golangci-lint-action@v7
         with:
-          version: v1.59
+          version: v2.0
       - run: go test -v ./...
       - run: |
           coveredFiles=$(go list ./... | grep -v 'github.com/zostay/ghost/\(cmd\|tools/gen/verses\)')

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,24 +1,14 @@
----
+version: "2"
 run:
   concurrency: 4
-
 linters:
   enable:
-    - errcheck
-    - gosimple
-    - govet
-    - ineffassign
-    - staticcheck
-    - typecheck
-    - unused
     - depguard
-    - errorlint
     - errname
+    - errorlint
     - exhaustive
-    - exportloopref
     - gocritic
     - godot
-    - gofmt
     - gosec
     - misspell
     - nolintlint
@@ -28,39 +18,57 @@ linters:
     - tparallel
     - unparam
     - whitespace
-
-linters-settings:
-  depguard:
-    rules:
-      main:
-        files:
-          - "$all"
-          - "!$test"
-          - "!**/pkg/secrets/keepertest/*.go"
-        allow:
-          - "$gostd"
-          - github.com/ansd/lastpass-go
-          - github.com/gobwas/glob
-          - github.com/golang
-          - github.com/gopasspw/pinentry
-          - github.com/mitchellh/mapstructure
-          - github.com/mitchellh/go-homedir
-          - github.com/ncruces/zenity
-          - github.com/oklog/ulid
-          - github.com/spf13/cobra
-          - github.com/spf13/pflag
-          - github.com/tobischo/gokeepasslib
-          - github.com/zalando/go-keyring
-          - github.com/zostay
-          - github.com/1Password/connect-sdk-go
-          - github.com/google/uuid
-
-      tests:
-        files:
-          - "$test"
-          - "**/pkg/secrets/keepertest/*.go"
-        allow:
-          - "$gostd"
-          - github.com/stretchr/testify
-          - github.com/zostay
-          - github.com/ansd/lastpass-go
+  settings:
+    depguard:
+      rules:
+        main:
+          files:
+            - $all
+            - '!$test'
+            - '!**/pkg/secrets/keepertest/*.go'
+          allow:
+            - $gostd
+            - github.com/ansd/lastpass-go
+            - github.com/gobwas/glob
+            - github.com/golang
+            - github.com/gopasspw/pinentry
+            - github.com/mitchellh/mapstructure
+            - github.com/mitchellh/go-homedir
+            - github.com/ncruces/zenity
+            - github.com/oklog/ulid
+            - github.com/spf13/cobra
+            - github.com/spf13/pflag
+            - github.com/tobischo/gokeepasslib
+            - github.com/zalando/go-keyring
+            - github.com/zostay
+            - github.com/1Password/connect-sdk-go
+            - github.com/google/uuid
+        tests:
+          files:
+            - $test
+            - '**/pkg/secrets/keepertest/*.go'
+          allow:
+            - $gostd
+            - github.com/stretchr/testify
+            - github.com/zostay
+            - github.com/ansd/lastpass-go
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -43,6 +43,11 @@ linters:
             - github.com/zostay
             - github.com/1Password/connect-sdk-go
             - github.com/google/uuid
+            - github.com/pborman/indent
+            - google.golang.org/grpc
+            - gopkg.in/yaml.v3
+            - golang.org/x/term
+            - google.golang.org/protobuf
         tests:
           files:
             - $test

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -48,6 +48,8 @@ linters:
             - gopkg.in/yaml.v3
             - golang.org/x/term
             - google.golang.org/protobuf
+            - golang.org/x/text/cases
+            - golang.org/x/text/language
         tests:
           files:
             - $test

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -12,6 +12,7 @@
         <function importPath="math/rand" name="Read" />
         <function importPath="errors" name="Unwrap" />
         <function importPath="fmt" name="Fprintln" />
+        <function importPath="fmt" name="Fprintf" />
       </functions>
     </inspection_tool>
   </profile>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,18 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="GoUnhandledErrorResult" enabled="true" level="WARNING" enabled_by_default="true">
+      <functions>
+        <function importPath="errors" name="Join" />
+        <function importPath="fmt" name="Errorf" />
+        <function importPath="fmt" name="Println" />
+        <function importPath="errors" name="New" />
+        <function importPath="fmt" name="Print" />
+        <function importPath="fmt" name="Printf" />
+        <function importPath="math/rand" name="Read" />
+        <function importPath="errors" name="Unwrap" />
+        <function importPath="fmt" name="Fprintln" />
+      </functions>
+    </inspection_tool>
+  </profile>
+</component>

--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,8 @@
+## WIP  TBD
+
+ * Fix: When printing configuration with the `config get` or `config list` commands, correctly print the configuration for 1password and cache.
+ * Fix: When printing configuration with the `config get` or `config list` commands, print full policy configuration.
+
 ## v0.6.2  2024-08-09
 
  * Fix `keyring` keeper so that not found errors are handled correctly.

--- a/Changes.md
+++ b/Changes.md
@@ -43,19 +43,19 @@
  * Added the `--verbose` flag to `ghost sync`.
  * Fix: A bug in how password worked could result in the password display being stuck on the screen permanently. This has been fixed.
  * Fix: (Experimental) Ghost was using a library for password entry that is no longer maintained. This has been switched to a new input mechanism. This may change again.
- * Fix: The `ghost config list` and `ghost config get` commands failed when secret references failed to fully resolve because they depende upon the secret service or something. Now, it may not list  complete configuration, but shouldn't fail or cause a password propmt just to call these sub-commands.
+ * Fix: The `ghost config list` and `ghost config get` commands failed when secret references failed to fully resolve because they depend upon the secret service or something. Now, it may not list  complete configuration, but shouldn't fail or cause a password prompt just to call these sub-commands.
  * Fix: When `ghost service start` runs, check the service status and perform an appropriate recovery routine to correct errors automatically.
  * Fix: The router service correctly validates default and routes keepers now.
 
 ## v0.3.0  2023-10-23
 
  * Add and implement the `GetServiceInfo` endpoint to the gRPC keeper service interface.
- * Add the `ghost service status` command to query the status of the gRPC keeper service, report it's PID, and report the keeper served and the policy enforcement configuration.
+ * Add the `ghost service status` command to query the status of the gRPC keeper service, report its PID, and report the keeper served and the policy enforcement configuration.
 
 ## v0.2.0  2023-09-04
 
  * Rewrite the `ghost sync` command to use name, username, and location as the index key.
- * Add the `keeper.Sync` object to help with copying between between keepers with `AddSecret`, `AddLocationSecret`, `AddSecretKeeper`, `CopyTo`, and `DeleteAbsent` methods and the `NewSync` constructor. This provides the implementation for the rewritten `ghost sync` command.
+ * Add the `keeper.Sync` object to help with copying between keepers with `AddSecret`, `AddLocationSecret`, `AddSecretKeeper`, `CopyTo`, and `DeleteAbsent` methods and the `NewSync` constructor. This provides the implementation for the rewritten `ghost sync` command.
  * Add retries with automatic back-off to the LastPass secret keeper using the same back-off strategy that lastpass-cli uses.
  * Fix: Use "UserName" as the field for the `Username` field in Keepass (previously, "Username" was incorrectly used).
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 > *CAUTION:* The state of LastPass in this library is pretty iffy. LastPass throttles their service so that it has become unusable for me and the Go library this uses to talk to LastPass appears to have been abandoned. It should be possible to use the CLI or do some CGO work to fix this, but I do not have time and have grown to dislike LastPass for most uses, so I'm not very motivated right now.
 
-This is a secret toolkit written in Go. I use it to backup my online password vault locally and to provide tooling to allow my scripts and such to retrieve secrets without having to store such things in environment files or other ways that make me nervous.
+This is a secret toolkit written in Go. I use it to back up my online password vault locally and to provide tooling to allow my scripts and such to retrieve secrets without having to store such things in environment files or other ways that make me nervous.
 
 I only use this on local machines that only I have access. I cannot vouch for the safety of transport or security of storage of any aspect of this system. As per the terms of the license, you use this software entirely at your own risk. I make no guarantees or warranties regarding the security or safety of this system.
 
@@ -247,7 +247,7 @@ Like the secret commands, you may use the `--keeper=<name>` option to specify th
 ghost service start --keeper=myPasswordService --enforce-all-policies
 ```
 
-This will start the password service running in the foreground. It can be set to run against any keeper specified with the `--keeper=<name>` setting or it will use the `master` keeper configuration.
+This will start the password service running in the foreground. It can be set to run against any keeper specified with the `--keeper=<name>` setting, or it will use the `master` keeper configuration.
 
 The `--enforce-all-policies` option will cause the server to locate all policy secret keepers and enforce all lifetime policies periodically. The period is determined by the value defined in `--enforcement-period`, which defaults to every minute. If you only want to enforce some of your policies this way, you can specify the policies using the `--enforce-policy` option instead.
 
@@ -281,7 +281,7 @@ You will need to look at the usage message for each of the keeper type sub-comma
 
 Sometimes an option will be provided in a special `--*-secret` variant. This allows you to specify a `__SECRET__` reference in the configuration for that particular setting from the command-line. To use it, you will pass a colon-separated list of the relevant fields: keeper, secret, and field.
 
-For example, to set the password to a secret reference in the a Keepass secret keeper, you could do something like this:
+For example, to set the password to a secret reference in the Keepass secret keeper, you could do something like this:
 
 ```
 ghost config set keepass myPasswords \
@@ -322,7 +322,7 @@ The way this is structured is heavily influenced by LastPass and Keepass.
 Basically, each item of data stored is called a **secret**. A secret has a number of fields. The only required field is ID. The only secure field is Password. The list of fields includes:
 
  * **ID**. Is the unique ID given to the secret in the store. Every secret stored must have a unique ID, but the format or length is not specified by this. That's up to the secret keeper.
- * **Name**. This is a title for the secret stored, describing it's purpose. For example, account information related to Facebook might have a name of "Facebook.com" while your wifi password might have the name "Home WiFi". The name is for human reference and is not secure. Names do not have to be unique and generally should not be expected to be unique.
+ * **Name**. This is a title for the secret stored, describing its purpose. For example, account information related to Facebook might have a name of "Facebook.com" while your Wi-Fi password might have the name "Home Wi-Fi". The name is for human reference and is not secure. Names do not have to be unique and generally should not be expected to be unique.
  * **Username**. This is the username for the account. This is not secure.
  * **Password**. This is the password or secret information stored. This is not secure.
  * **URL**. This is the URL of the account, if any.
@@ -339,11 +339,11 @@ A **secret keeper** is a configured storage for secrets. The keepers are divided
 
 The following primary secret keeper types are provided:
 
- * `1password` - The 1Password secret keeper uses the 1Password Connect Server API to access secrets. You will need a 1Password family, business, or enterprise account and some shared vaults. Then you will need to setup a 1Password Connect Server running somewhere.
+ * `1password` - The 1Password secret keeper uses the 1Password Connect Server API to access secrets. You will need a 1Password family, business, or enterprise account and some shared vaults. Then you will need to set up a 1Password Connect Server running somewhere.
  * `http` - The http secret keeper accesses secrets provided by the ghost gRPC service. The ghost service can be run with the `ghost service start` command and used to wrap any keeper in the given configuration. As of this writing, the http keeper may only be used on a local machine as all communication is performed over a unix socket.
  * `human` - The human secret keeper provides a means of asking the person at the keyboard to enter a secret. A human keeper is configured with a number of questions, each acting as a secret the user is expected to supply upon request.
  * `keepass` - The Keepass secret keeper loads and stores secrets in a local Keepass database file. You will need to provide the Keepass secret keeper the path to the file as well as the master password for encrypting and decrypting the file.
- * `keyring` - The keyring secret keeper loads and stores passwords in the system keyring. This should work on macOS, Windows, Linux, and BSD. On macOS it accesses the system keyring using the `security` command. Similarly, it uses the Windows OS keyring on Windows. On Linux and BSD, it uses dbus to communicate with whatever secret service is installed, usually GNOME Keyring. 
+ * `keyring` - The keyring secret keeper loads and stores passwords in the system keyring. This should work on macOS, Windows, Linux, and BSD. On macOS, it accesses the system keyring using the `security` command. Similarly, it uses the Windows OS keyring on Windows. On Linux and BSD, it uses dbus to communicate with whatever secret service is installed, usually GNOME Keyring. 
  * `lastpass` - The LastPass secret keeper uses the LastPass API to access secrets. The secrets are downloaded from the online store and then decrypted locally on get and encrypted locally and set to the online store during set.
  * `low` - The low security secret keeper stores secrets in a local YAML file in plaintext. This is obviously only suitable for secrets that are not very secure or on a system you are very confident in.
  * `memory` - The memory secret keeper will hold a secret encrypted in memory for the duration of the process. Used with the ghost command, this is not very useful. However, it can be useful as a memory store within the ghost service or embedded in an application. The encryption used doesn't guarantee much in the way of safety as the key is also stored in memory, so it may even be considered superfluous.
@@ -352,7 +352,7 @@ The following primary secret keeper types are provided:
 
 The secondary secret keepers exist to provide additional services on top of another secret keeper store. Here is a list of secondary keepers that are provided.
 
- * `cache` - The cache secret keeper is based on the memory secret keeper and wraps some other keeper. Whenever the keeper is used for getting a secret, the secret is saved locally. A `cache` keeper does not permit any write operations except delete, which just deletes a secret from the cache. It does not delete the secret from the wrapped store. This is another keeper that is not much use outside of either the ghost service or embedded application.
+ * `cache` - The cache secret keeper is based on the memory secret keeper and wraps some other keeper. Whenever the keeper is used for getting a secret, the secret is saved locally. A `cache` keeper does not permit any write operations except delete, which just deletes a secret from the cache. It does not delete the secret from the wrapped store. This is another keeper that is not much use outside the ghost service or embedded application.
  * `router` - The router secret keeper combined other secret keepers into a single logical keeper. It uses location as the means by which to decide which keeper to use when getting and storing secrets. If a location that does not match any of the configured routes is used, then a default keeper is used to store that secret.
  * `seq` - The sequential secret keeper combines multiple secret keepers into a single logical keeper. When getting secrets, each keeper is checked for that secret in turn and the first secret found to match is returned. When setting, only the first secret keeper in the sequence is modified.
 

--- a/cmd/config/delete.go
+++ b/cmd/config/delete.go
@@ -14,7 +14,7 @@ var DeleteCmd = &cobra.Command{
 	Run:   RunDeleteConfig,
 }
 
-func RunDeleteConfig(cmd *cobra.Command, args []string) {
+func RunDeleteConfig(_ *cobra.Command, args []string) {
 	keeperName := args[0]
 	c := config.Instance()
 

--- a/cmd/config/get.go
+++ b/cmd/config/get.go
@@ -24,7 +24,7 @@ var GetCmd = &cobra.Command{
 func RunGet(cmd *cobra.Command, args []string) {
 	keeperName := args[0]
 	c := config.Instance()
-	ctx := keeper.WithBuilder(context.Background(), c)
+	ctx := keeper.WithBuilder(cmd.Context(), c)
 	kpr, hasKeeper := c.Keepers[keeperName]
 	if !hasKeeper {
 		s.Logger.Panicf("Keeper %q is not configured.", keeperName)

--- a/cmd/config/get.go
+++ b/cmd/config/get.go
@@ -1,25 +1,17 @@
 package config
 
 import (
+	"bytes"
 	"context"
 	"strings"
 
+	"github.com/pborman/indent"
 	"github.com/spf13/cobra"
 
 	s "github.com/zostay/ghost/cmd/shared"
 	"github.com/zostay/ghost/pkg/config"
 	"github.com/zostay/ghost/pkg/keeper"
 	"github.com/zostay/ghost/pkg/plugin"
-	"github.com/zostay/ghost/pkg/secrets/http"
-	"github.com/zostay/ghost/pkg/secrets/human"
-	"github.com/zostay/ghost/pkg/secrets/keepass"
-	"github.com/zostay/ghost/pkg/secrets/keyring"
-	"github.com/zostay/ghost/pkg/secrets/lastpass"
-	"github.com/zostay/ghost/pkg/secrets/low"
-	"github.com/zostay/ghost/pkg/secrets/memory"
-	"github.com/zostay/ghost/pkg/secrets/policy"
-	"github.com/zostay/ghost/pkg/secrets/router"
-	"github.com/zostay/ghost/pkg/secrets/seq"
 )
 
 var GetCmd = &cobra.Command{
@@ -51,77 +43,24 @@ func PrintKeeper(
 	kc config.KeeperConfig,
 	i int,
 ) {
-	// TODO this should be rolled into plugin configuration too
-	indent := makeIndent(i)
+	sp := makeIndent(i)
 	dc, err := keeper.DecodePartial(ctx, keeperName)
 	if err != nil {
-		s.Printer.Panicf("failed to decode configuration for keeper %q: %v", keeperName, err)
+		s.Printer.Printf("%sERROR: failed to decode configuration for keeper %q: %v", sp, keeperName, err)
 	}
-	s.Printer.Printf("%stype: %s", indent, plugin.Type(kc))
-	switch plugin.Type(kc) {
-	case keepass.ConfigType:
-		kpc := dc.(*keepass.Config)
-		s.Printer.Printf("%spath: %s", indent, kpc.Path)
-		s.Printer.Printf("%smaster: <hidden>", indent)
-	case lastpass.ConfigType:
-		lpc := dc.(*lastpass.Config)
-		s.Printer.Printf("%susername: %s", indent, lpc.Username)
-		s.Printer.Printf("%spassword: <hidden>", indent)
-	case low.ConfigType:
-		lc := dc.(*low.Config)
-		s.Printer.Printf("%spath: %s", indent, lc.Path)
-	case http.ConfigType:
-	case keyring.ConfigType:
-		krc := dc.(*keyring.Config)
-		s.Printer.Printf("%skeyring: %s", indent, krc.ServiceName)
-	case memory.ConfigType:
-	case human.ConfigType:
-		hc := dc.(*human.Config)
-		s.Printer.Printf("%squestions:", indent)
-		for _, q := range hc.Questions {
-			indentP1 := makeIndent(i + 1)
-			indentP2 := makeIndent(i + 2)
-			s.Printer.Printf("%s- id: %s", indent, q.ID)
-			if len(q.Presets) > 0 {
-				s.Printer.Printf("%spresets:", indentP1)
-				for k, v := range q.Presets {
-					s.Printer.Printf("%s%s = %s", indentP2, k, v)
-				}
-			}
-			s.Printer.Printf("%sasking for: %s", indentP1, strings.Join(q.AskFor, ", "))
-		}
-	case policy.ConfigType:
-		pc := dc.(*policy.Config)
-		s.Printer.Printf("%skeeper: %s", indent, pc.Keeper)
-		s.Printer.Printf("%sdefault rule:", indent)
-		s.Printer.Printf("%s  acceptance: %s", indent, pc.DefaultRule.Acceptance)
-		if pc.DefaultRule.Lifetime >= 0 {
-			s.Printer.Printf("%s  lifetime: %v", indent, pc.DefaultRule.Lifetime)
-		}
-		s.Printer.Printf("%srules:", indent)
-		for _, r := range pc.Rules {
-			if policy.ValidAcceptance(r.Acceptance, false) {
-				s.Printer.Printf("%s - acceptance: %s", indent, r.Acceptance)
-			}
-			if r.Lifetime > 0 {
-				s.Printer.Printf("%s - lifetime: %v", indent, r.Lifetime)
-			}
-		}
-	case router.ConfigType:
-		rc := dc.(*router.Config)
-		s.Printer.Printf("%sdefault route: %s", indent, rc.DefaultRoute)
-		s.Printer.Printf("%sroutes:", indent)
-		for _, route := range rc.Routes {
-			s.Printer.Printf("%s - locations: %s", indent, strings.Join(route.Locations, ", "))
-			s.Printer.Printf("%s   keeper: %s", indent, route.Keeper)
-		}
-	case seq.ConfigType:
-		sc := dc.(*seq.Config)
-		s.Printer.Printf("%skeepers:", indent)
-		for _, name := range sc.Keepers {
-			s.Printer.Printf("%s  - %s", indent, name)
-		}
-	default:
-		s.Printer.Printf("%sERROR: unknown keeper type", indent)
+	typ := plugin.Type(kc)
+	s.Printer.Printf("%stype: %s", sp, plugin.Type(kc))
+	r, hasKeeper := plugin.Get(typ)
+	if !hasKeeper {
+		s.Printer.Printf("%sERROR: unknown keeper type", sp)
 	}
+
+	buf := &bytes.Buffer{}
+	w := indent.New(buf, sp)
+	err = r.Printer(dc, w)
+	if err != nil {
+		s.Printer.Printf("%sERROR: failed to print configuration for keeper %q: %v", sp, keeperName, err)
+	}
+
+	s.Printer.Print(buf.String())
 }

--- a/cmd/config/list.go
+++ b/cmd/config/list.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"context"
 	"sort"
 
 	"github.com/spf13/cobra"
@@ -19,9 +18,9 @@ var ListCmd = &cobra.Command{
 	Run:   RunListConfig,
 }
 
-func RunListConfig(cmd *cobra.Command, args []string) {
+func RunListConfig(cmd *cobra.Command, _ []string) {
 	c := config.Instance()
-	ctx := keeper.WithBuilder(context.Background(), c)
+	ctx := keeper.WithBuilder(cmd.Context(), c)
 
 	keys := maps.Keys(c.Keepers)
 	sort.Strings(keys)

--- a/cmd/config/set.go
+++ b/cmd/config/set.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -97,7 +96,7 @@ func RunSetKeeperConfig(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	err := keeper.CheckConfig(context.Background(), c)
+	err := keeper.CheckConfig(cmd.Context(), c)
 	if err != nil {
 		s.Logger.Panicf("Configuration failed. Configuration errors: %v", err)
 		return

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"context"
-
 	"github.com/spf13/cobra"
 
 	s "github.com/zostay/ghost/cmd/shared"
@@ -23,7 +21,7 @@ func init() {
 	deleteCmd.Flags().StringVar(&name, "name", "", "The name of the secret to get")
 }
 
-func RunDelete(cmd *cobra.Command, args []string) {
+func RunDelete(cmd *cobra.Command, _ []string) {
 	if name != "" && id != "" {
 		s.Logger.Panic("Cannot specify both --id and --name.")
 	}
@@ -45,7 +43,7 @@ func RunDelete(cmd *cobra.Command, args []string) {
 		s.Logger.Panicf("No keeper named %q.", keeperName)
 	}
 
-	ctx := keeper.WithBuilder(context.Background(), c)
+	ctx := keeper.WithBuilder(cmd.Context(), c)
 	kpr, err := keeper.Build(ctx, keeperName)
 	if err != nil {
 		s.Logger.Panic(err)

--- a/cmd/enforce-policy.go
+++ b/cmd/enforce-policy.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"context"
-
 	"github.com/spf13/cobra"
 
 	s "github.com/zostay/ghost/cmd/shared"
@@ -31,7 +29,7 @@ func RunEnforcePolicy(cmd *cobra.Command, args []string) {
 		s.Logger.Panicf("Keeper %q is not a policy keeper.", keeperName)
 	}
 
-	ctx := keeper.WithBuilder(context.Background(), c)
+	ctx := keeper.WithBuilder(cmd.Context(), c)
 	kpr, err := keeper.Build(ctx, keeperName)
 	if err != nil {
 		s.Logger.Panicf("Failed to load keeper %q: %s", keeperName, err)

--- a/cmd/flag/secret.go
+++ b/cmd/flag/secret.go
@@ -18,14 +18,14 @@ func (s *Secret) Set(value string) error {
 		return errors.New("secret lookups must be in the form of <keeper>:<secret>:<field-name>")
 	}
 
-	s.SecretRef.KeeperName, s.SecretRef.SecretName, s.SecretRef.Field = parts[0], parts[1], parts[2]
+	s.KeeperName, s.SecretName, s.Field = parts[0], parts[1], parts[2]
 
 	c := config.Instance()
-	if _, hasKeeper := c.Keepers[s.SecretRef.KeeperName]; !hasKeeper {
+	if _, hasKeeper := c.Keepers[s.KeeperName]; !hasKeeper {
 		return fmt.Errorf("secret lookup names keeper %q which does not exist", s.KeeperName)
 	}
 
-	if s.SecretRef.SecretName == "" {
+	if s.SecretName == "" {
 		return fmt.Errorf("empty secret identifier named")
 	}
 
@@ -37,7 +37,7 @@ func (s *Secret) Set(value string) error {
 }
 
 func (s *Secret) String() string {
-	return fmt.Sprintf("%s:%s:%s", s.SecretRef.KeeperName, s.SecretRef.SecretName, s.Field)
+	return fmt.Sprintf("%s:%s:%s", s.KeeperName, s.SecretName, s.Field)
 }
 
 func (s *Secret) Type() string {

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"encoding/json"
 	"strings"
 
@@ -43,7 +42,7 @@ func init() {
 	getCmd.Flags().StringVar(&envPrefix, "env-prefix", "", "The prefix to use when output is env")
 }
 
-func RunGet(cmd *cobra.Command, args []string) {
+func RunGet(cmd *cobra.Command, _ []string) {
 	if name != "" && id != "" {
 		s.Logger.Panic("Cannot specify both --id and --name.")
 	}
@@ -65,13 +64,13 @@ func RunGet(cmd *cobra.Command, args []string) {
 		s.Logger.Panicf("No keeper named %q.", keeperName)
 	}
 
-	ctx := keeper.WithBuilder(context.Background(), c)
+	ctx := keeper.WithBuilder(cmd.Context(), c)
 	kpr, err := keeper.Build(ctx, keeperName)
 	if err != nil {
 		s.Logger.Panic(err)
 	}
 
-	secs := []secrets.Secret{}
+	var secs []secrets.Secret
 	if id != "" {
 		sec, err := kpr.GetSecret(ctx, id)
 		if err != nil {

--- a/cmd/list/locations.go
+++ b/cmd/list/locations.go
@@ -1,8 +1,6 @@
 package list
 
 import (
-	"context"
-
 	"github.com/spf13/cobra"
 
 	s "github.com/zostay/ghost/cmd/shared"
@@ -21,7 +19,7 @@ func init() {
 	LocationsCmd.Flags().StringVar(&keeperName, "keeper", "", "The name of the secret keeper to use")
 }
 
-func RunListLocations(cmd *cobra.Command, args []string) {
+func RunListLocations(cmd *cobra.Command, _ []string) {
 	c := config.Instance()
 	if keeperName == "" {
 		keeperName = c.MasterKeeper
@@ -35,7 +33,7 @@ func RunListLocations(cmd *cobra.Command, args []string) {
 		s.Logger.Panicf("No keeper named %q.", keeperName)
 	}
 
-	ctx := keeper.WithBuilder(context.Background(), c)
+	ctx := keeper.WithBuilder(cmd.Context(), c)
 	kpr, err := keeper.Build(ctx, keeperName)
 	if err != nil {
 		s.Logger.Panic(err)

--- a/cmd/list/plugins.go
+++ b/cmd/list/plugins.go
@@ -14,7 +14,7 @@ var PluginsCmd = &cobra.Command{
 	Run:   RunListPlugins,
 }
 
-func RunListPlugins(cmd *cobra.Command, args []string) {
+func RunListPlugins(_ *cobra.Command, _ []string) {
 	for _, kt := range plugin.List() {
 		s.Printer.Print(kt)
 	}

--- a/cmd/list/secrets.go
+++ b/cmd/list/secrets.go
@@ -1,8 +1,6 @@
 package list
 
 import (
-	"context"
-
 	"github.com/spf13/cobra"
 
 	s "github.com/zostay/ghost/cmd/shared"
@@ -34,7 +32,7 @@ func init() {
 	}
 }
 
-func RunListSecrets(cmd *cobra.Command, args []string) {
+func RunListSecrets(cmd *cobra.Command, _ []string) {
 	c := config.Instance()
 	if keeperName == "" {
 		keeperName = c.MasterKeeper
@@ -48,7 +46,7 @@ func RunListSecrets(cmd *cobra.Command, args []string) {
 		s.Logger.Panicf("No keeper named %q.", keeperName)
 	}
 
-	ctx := keeper.WithBuilder(context.Background(), c)
+	ctx := keeper.WithBuilder(cmd.Context(), c)
 	kpr, err := keeper.Build(ctx, keeperName)
 	if err != nil {
 		s.Logger.Panic(err)

--- a/cmd/random-password.go
+++ b/cmd/random-password.go
@@ -165,8 +165,8 @@ func pick[T any](from []T) T {
 	return from[p.Int64()]
 }
 
-func randomInt(max int) int {
-	p, err := rand.Int(rand.Reader, big.NewInt(int64(max)))
+func randomInt(mx int) int {
+	p, err := rand.Int(rand.Reader, big.NewInt(int64(mx)))
 	if err != nil {
 		s.Logger.Panic(err)
 	}

--- a/cmd/random-password.go
+++ b/cmd/random-password.go
@@ -157,8 +157,8 @@ func sample[T any](from []T, count int) []T {
 }
 
 func pick[T any](from []T) T {
-	max := big.NewInt(int64(len(from)))
-	p, err := rand.Int(rand.Reader, max)
+	mx := big.NewInt(int64(len(from)))
+	p, err := rand.Int(rand.Reader, mx)
 	if err != nil {
 		s.Logger.Panic(err)
 	}

--- a/cmd/service/start.go
+++ b/cmd/service/start.go
@@ -33,7 +33,7 @@ func init() {
 	StartCmd.Flags().StringVar(&keeperService, "keeper", "", "the name of the keeper service to use (master used by default)")
 }
 
-func RunStartService(cmd *cobra.Command, args []string) {
+func RunStartService(cmd *cobra.Command, _ []string) {
 	if enforceAllPolicies && len(enforcePolicies) > 0 {
 		s.Logger.Panic("cannot use --enforce-all-policies and --enforce-policy together")
 		return
@@ -60,7 +60,7 @@ func RunStartService(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	ctx := keeper.WithBuilder(context.Background(), c)
+	ctx := keeper.WithBuilder(cmd.Context(), c)
 	kpr, err := keeper.Build(ctx, keeperService)
 	if err != nil {
 		s.Logger.Panicf("Failed to configure master keeper %q: %v", keeperService, err)

--- a/cmd/service/status.go
+++ b/cmd/service/status.go
@@ -14,7 +14,7 @@ var (
 	}
 )
 
-func RunServiceStatus(cmd *cobra.Command, args []string) {
+func RunServiceStatus(_ *cobra.Command, _ []string) {
 	info, err := keeper.CheckServer()
 	if err != nil {
 		s.Logger.Panic(err)

--- a/cmd/service/stop.go
+++ b/cmd/service/stop.go
@@ -23,7 +23,7 @@ func init() {
 	StopCmd.Flags().BoolVar(&kill, "kill", false, "send SIGKILL instead of SIGHUP")
 }
 
-func RunStopService(cmd *cobra.Command, args []string) {
+func RunStopService(_ *cobra.Command, _ []string) {
 	quickness := keeper.StopGraceful
 	switch {
 	case kill:

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"errors"
 	neturl "net/url"
 
@@ -44,7 +43,7 @@ func init() {
 	setCmd.Flags().StringToStringVar(&setFlds, "field", map[string]string{}, "The new fields to set")
 }
 
-func RunSet(cmd *cobra.Command, args []string) {
+func RunSet(cmd *cobra.Command, _ []string) {
 	if name != "" && id != "" {
 		s.Logger.Panic("Cannot specify both --id and --name.")
 	}
@@ -88,7 +87,7 @@ func RunSet(cmd *cobra.Command, args []string) {
 		s.Logger.Panicf("No keeper named %q.", keeperName)
 	}
 
-	ctx := keeper.WithBuilder(context.Background(), c)
+	ctx := keeper.WithBuilder(cmd.Context(), c)
 	kpr, err := keeper.Build(ctx, keeperName)
 	if err != nil {
 		s.Logger.Panic(err)

--- a/cmd/shared/run.go
+++ b/cmd/shared/run.go
@@ -1,7 +1,6 @@
 package shared
 
 import (
-	"context"
 	"log"
 
 	"github.com/spf13/cobra"
@@ -10,7 +9,7 @@ import (
 	"github.com/zostay/ghost/pkg/keeper"
 )
 
-func RunRoot(cmd *cobra.Command, args []string) {
+func RunRoot(cmd *cobra.Command, _ []string) {
 	Logger = log.New(cmd.OutOrStderr(), "", 0)
 	Printer = log.New(cmd.OutOrStdout(), "", 0)
 
@@ -21,7 +20,7 @@ func RunRoot(cmd *cobra.Command, args []string) {
 	}
 
 	cfg := config.Instance()
-	ctx := keeper.WithBuilder(context.Background(), cfg)
+	ctx := keeper.WithBuilder(cmd.Context(), cfg)
 	err = keeper.CheckConfig(ctx, cfg)
 	if err != nil {
 		Logger.Panicf("Configuration errors: %v", err)

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"errors"
 
 	"github.com/spf13/cobra"
@@ -45,12 +44,12 @@ func init() {
 	syncCmd.Flags().BoolVar(&overwriteMatching, "overwrite-matching", false, "When synchronizing, overwrite secrets in the destination that match the source (by name, username, and location).")
 }
 
-func RunSync(_ *cobra.Command, args []string) {
+func RunSync(cmd *cobra.Command, args []string) {
 	fromKeeper := args[0]
 	toKeeper := args[1]
 
 	c := config.Instance()
-	ctx := keeper.WithBuilder(context.Background(), c)
+	ctx := keeper.WithBuilder(cmd.Context(), c)
 	fromKpr, err := keeper.Build(ctx, fromKeeper)
 	if err != nil {
 		s.Logger.Panic(err)

--- a/examples/secure-insecure.ghost.yaml
+++ b/examples/secure-insecure.ghost.yaml
@@ -1,5 +1,5 @@
 # Sometimes you may want to treat some secrets less carefully and don't mind
-# storing them in a plaintext file. For example, you may want to store a github
+# storing them in a plaintext file. For example, you may want to store a GitHub
 # API token on your laptop in a plaintext file.
 #
 # Using ghost, you can have some secrets stored securely and others not. Here

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/ncruces/zenity v0.10.13
 	github.com/oklog/ulid/v2 v2.1.0
+	github.com/pborman/indent v1.2.1
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -86,6 +86,8 @@ github.com/onsi/gomega v1.20.2/go.mod h1:iYAIXgPSaDHak0LCMA+AWBpIKBr8WZicMxnE8lu
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
+github.com/pborman/indent v1.2.1 h1:lFiviAbISHv3Rf0jcuh489bi06hj98JsVMtIDZQb9yM=
+github.com/pborman/indent v1.2.1/go.mod h1:FitS+t35kIYtB5xWTZAPhnmrxcciEEOdbyrrpz5K6Vw=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -99,10 +99,10 @@ func (c *Config) Save(requestedPath string) error {
 	if err != nil {
 		return err
 	}
-	defer cf.Close()
+	defer func() { _ = cf.Close() }()
 
 	enc := yaml.NewEncoder(cf)
-	defer enc.Close()
+	defer func() { _ = enc.Close() }()
 	enc.SetIndent(2)
 	err = enc.Encode(c)
 	if err != nil {

--- a/pkg/keeper/builder.go
+++ b/pkg/keeper/builder.go
@@ -80,7 +80,7 @@ func Build(ctx context.Context, name string) (secrets.Keeper, error) {
 	return nil, errors.New("unable to find the secret keeper factory in context")
 }
 
-// Validate checks that the configuration int he context is correct for the
+// Validate checks that the configuration in the context is correct for the
 // named secret keeper.
 func Validate(ctx context.Context, name string) error {
 	builder, isBuilder := ctx.Value(builderKey{}).(*builderContext)

--- a/pkg/keeper/builder.go
+++ b/pkg/keeper/builder.go
@@ -111,19 +111,6 @@ func Exists(ctx context.Context, name string) bool {
 	return builder.c.Keepers[name] != nil
 }
 
-// Decode decodes the configuration for the named secret keeper into its
-// preferred configuration type. This is useful for tools that want to
-// manipulate the configuration directly. This will have any secret references
-// resolved and lookups performed.
-func Decode(ctx context.Context, name string) (any, error) {
-	builder, isBuilder := ctx.Value(builderKey{}).(*builderContext)
-	if !isBuilder {
-		panic("unable to find the secret keeper factory in context")
-	}
-
-	return builder.Decode(name)
-}
-
 // DecodePartial works the same as Decode, but does not resolve secret
 // references.
 func DecodePartial(ctx context.Context, name string) (any, error) {

--- a/pkg/keeper/check.go
+++ b/pkg/keeper/check.go
@@ -8,7 +8,7 @@ import (
 	"github.com/zostay/ghost/pkg/plugin"
 )
 
-// CheckConfig validates the configuration for all of ghost.
+// CheckConfig validates the configuration for all of the ghost app.
 func CheckConfig(ctx context.Context, c *config.Config) error {
 	errs := plugin.NewValidationError()
 

--- a/pkg/keeper/pinentry.go
+++ b/pkg/keeper/pinentry.go
@@ -32,7 +32,7 @@ func getGUIPassword(title, desc, prompt, ok string) (string, error) {
 	return x, nil
 }
 
-func getTermPassword(_, _, prompt, _ string) (string, error) { //nolint:unparam
+func getTermPassword(_, _, prompt, _ string) (string, error) {
 	fmt.Print(prompt + ": ")
 	x, err := term.ReadPassword(int(os.Stdin.Fd()))
 	if err != nil {

--- a/pkg/keeper/pinentry.go
+++ b/pkg/keeper/pinentry.go
@@ -32,7 +32,7 @@ func getGUIPassword(title, desc, prompt, ok string) (string, error) {
 	return x, nil
 }
 
-func getTermPassword(title, desc, prompt, ok string) (string, error) { //nolint:unparam
+func getTermPassword(_, _, prompt, _ string) (string, error) { //nolint:unparam
 	fmt.Print(prompt + ": ")
 	x, err := term.ReadPassword(int(os.Stdin.Fd()))
 	if err != nil {

--- a/pkg/keeper/server.go
+++ b/pkg/keeper/server.go
@@ -248,7 +248,7 @@ func RecoverService() error {
 		errors.Is(err, ErrGRPCClient) ||
 		errors.Is(err, ErrProcessVerification) {
 		// The process appears to be in a bad state.
-		// There'll be killins' next. ~~ Hagrid
+		// There'll be killin's next. ~~ Hagrid
 		return killProcess()
 	}
 

--- a/pkg/keeper/sync.go
+++ b/pkg/keeper/sync.go
@@ -38,7 +38,7 @@ func makeKey(sec secrets.Secret) secretKey {
 // This works by using calls to one or more of the Add* methods to configure the
 // secrets to sync. Then CopyTo can be used to send these secrets to another
 // secret keeper. The DeleteAbsent will delete any secrets in the given secret
-// keeper that have not be added using the Add* methods.
+// keeper that have not been added using the Add* methods.
 type Sync struct {
 	gatherer secrets.Keeper
 	index    map[secretKey]localKey
@@ -202,7 +202,7 @@ func WithLogger(logger *log.Logger) SyncOption {
 }
 
 // WithMatchingOverwritten causes the CopyTo method to overwrite existing secrets in the
-// destination keeper. The secrets will be overwritten, if the have the same
+// destination keeper. The secrets will be overwritten, if they have the same
 // name, username, and location in the destination. If there are multiple secrets
 // with the same name, username, and location in the destination, the most
 // recently modified secret will be overwritten.

--- a/pkg/plugin/config.go
+++ b/pkg/plugin/config.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"reflect"
 	"sort"
 
@@ -30,6 +31,12 @@ type BuilderFunc func(context.Context, any) (secrets.Keeper, error)
 // recommended that the errors returned by the ValidatorFunc be build using the
 // ValidationError type.
 type ValidatorFunc func(context.Context, any) error
+
+// PrintConfigFunc is a function that should summarize the configuration for the
+// secret keeper to help the user introspect how the configuration has been
+// read and understood. The first argument is the configuration object and the
+// second is the writer to write the summary to.
+type PrintConfigFunc func(any, io.Writer) error
 
 // CmdFunc is a function that gets run via the command-line interface. It is
 // used to configure the secret keeper. The CmdFunc will be editing the
@@ -76,6 +83,7 @@ type RegisteredConfig struct {
 	Config    reflect.Type
 	Builder   BuilderFunc
 	Validator ValidatorFunc
+	Printer   PrintConfigFunc
 	CmdConfig CmdConfig
 }
 
@@ -100,6 +108,7 @@ func Register(
 	config reflect.Type,
 	builder BuilderFunc,
 	validator ValidatorFunc,
+	printer PrintConfigFunc,
 	cmdConfig CmdConfig,
 ) {
 	if _, ok := configs[name]; ok {
@@ -118,6 +127,7 @@ func Register(
 		Config:    config,
 		Builder:   builder,
 		Validator: validator,
+		Printer:   printer,
 		CmdConfig: cmdConfig,
 	}
 }

--- a/pkg/plugin/config.go
+++ b/pkg/plugin/config.go
@@ -18,7 +18,7 @@ import (
 // type.
 var ErrConfig = errors.New("incorrect configuration")
 
-// BuilderFunc is a factory function that should returned a constructed secret
+// BuilderFunc is a factory function that should return a constructed secret
 // keeper object from the given configuration. The BuilderFunc should expect the
 // configuration to be provided as the type defined in the Config field of
 // RegisteredConfig. If it is not that type, it should return ErrConfig.
@@ -42,7 +42,7 @@ type PrintConfigFunc func(any, io.Writer) error
 // used to configure the secret keeper. The CmdFunc will be editing the
 // configuration for the keeper with the given name. The name is provided in
 // case your configuration command needs to build up the configuration
-// incrementally and so it can lookup the configuration and modify it. The
+// incrementally and so it can look up the configuration and modify it. The
 // fields argument will contain those fields that have been configured via the
 // Fields field of CmdConfig. These will either be a literal string value or a
 // secret reference, which has the form of a map. The CmdFunc should return the
@@ -98,7 +98,7 @@ var configs = map[string]RegisteredConfig{}
 // command.
 //
 // This should be run in an init function in your plugin. Packages containing a
-// secret keeper should be added to main.go for import side-effects. At this
+// secret keeper should be added to main.go for import side effects. At this
 // time, new plugins require a pull request or a fork of the software. Patches welcome.
 //
 // If there's demand for more custom plugins, I could look into a plugin

--- a/pkg/secrets/cache/config.go
+++ b/pkg/secrets/cache/config.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"context"
 	"fmt"
+	"io"
 	"reflect"
 
 	"github.com/spf13/cobra"
@@ -59,6 +60,18 @@ func Validate(ctx context.Context, c any) error {
 	return nil
 }
 
+// Print is the config printer for teh cache keeper.
+func Print(c any, w io.Writer) error {
+	cfg, isCache := c.(*Config)
+	if !isCache {
+		return plugin.ErrConfig
+	}
+
+	fmt.Fprintln(w, "cache keeper:", cfg.Keeper)
+	fmt.Fprintln(w, "update cache time on read:", cfg.TouchOnRead)
+	return nil
+}
+
 func init() {
 	var (
 		keeperName  string
@@ -86,5 +99,5 @@ func init() {
 		},
 	}
 
-	plugin.Register(ConfigType, reflect.TypeOf(Config{}), Builder, Validate, cmd)
+	plugin.Register(ConfigType, reflect.TypeOf(Config{}), Builder, Validate, Print, cmd)
 }

--- a/pkg/secrets/cache/config.go
+++ b/pkg/secrets/cache/config.go
@@ -60,7 +60,7 @@ func Validate(ctx context.Context, c any) error {
 	return nil
 }
 
-// Print is the config printer for teh cache keeper.
+// Print is the config printer for the cache keeper.
 func Print(c any, w io.Writer) error {
 	cfg, isCache := c.(*Config)
 	if !isCache {

--- a/pkg/secrets/http/client.go
+++ b/pkg/secrets/http/client.go
@@ -28,7 +28,7 @@ func (c *Client) ListLocations(ctx context.Context) ([]string, error) {
 		return nil, err
 	}
 
-	locations := []string{}
+	var locations []string
 	for {
 		loc, err := locStream.Recv()
 		if errors.Is(err, io.EOF) {
@@ -51,7 +51,7 @@ func (c *Client) ListSecrets(ctx context.Context, location string) ([]string, er
 		return nil, err
 	}
 
-	secs := []string{}
+	var secs []string
 	for {
 		sec, err := secStream.Recv()
 		if errors.Is(err, io.EOF) {
@@ -88,7 +88,7 @@ func (c *Client) GetSecretsByName(ctx context.Context, name string) ([]secrets.S
 		return nil, err
 	}
 
-	secs := []secrets.Secret{}
+	var secs []secrets.Secret
 	for {
 		sec, err := rawSecs.Recv()
 		if errors.Is(err, io.EOF) {

--- a/pkg/secrets/http/config.go
+++ b/pkg/secrets/http/config.go
@@ -61,7 +61,7 @@ func init() {
 		},
 	}
 
-	plugin.Register(ConfigType, reflect.TypeOf(Config{}), Builder, nil, cmd)
+	plugin.Register(ConfigType, reflect.TypeOf(Config{}), Builder, nil, nil, cmd)
 }
 
 func MakeHttpServerSocketName() string {

--- a/pkg/secrets/http/server.go
+++ b/pkg/secrets/http/server.go
@@ -2,10 +2,10 @@ package http
 
 import (
 	"context"
-	"google.golang.org/protobuf/types/known/durationpb"
 	"time"
 
 	"github.com/golang/protobuf/ptypes/empty"
+	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/zostay/ghost/pkg/secrets"
 )

--- a/pkg/secrets/human/config.go
+++ b/pkg/secrets/human/config.go
@@ -17,7 +17,7 @@ import (
 	"github.com/zostay/ghost/pkg/secrets"
 )
 
-// ConfigType is the type name for the human secrets keeper.
+// ConfigType is the type name for the human secret keeper.
 const ConfigType = "human"
 
 // QuestionConfig is the configuration for a single question. Each question
@@ -37,13 +37,13 @@ type QuestionConfig struct {
 	AskFor []string `mapstructure:"ask_for" yaml:"ask_for"`
 }
 
-// Config is the configuration of the human secrets keeper.
+// Config is the configuration of the human secret keeper.
 type Config struct {
 	// Questions is the list of questions that will be asked of the user.
 	Questions []QuestionConfig `mapstructure:"questions" yaml:"questions"`
 }
 
-// Validator checks that the configuration is correct for the human secrets
+// Validator checks that the configuration is correct for the human secret
 // keeper. It will check that every question has at least one field to ask
 // for and that no question has a preset that is already being asked for.
 func Validator(_ context.Context, c any) error {
@@ -90,7 +90,7 @@ func Builder(_ context.Context, c any) (secrets.Keeper, error) {
 	return kpr, nil
 }
 
-// Print prints the configuration of the human secrets keeper.
+// Print prints the configuration of the human secret keeper.
 func Print(c any, w io.Writer) error {
 	cfg, isHuman := c.(*Config)
 	if !isHuman {

--- a/pkg/secrets/human/human.go
+++ b/pkg/secrets/human/human.go
@@ -132,21 +132,21 @@ func (h *Human) GetSecretsByName(ctx context.Context, name string) ([]secrets.Se
 }
 
 // SetSecret fails with an error.
-func (h *Human) SetSecret(_ context.Context, secret secrets.Secret) (secrets.Secret, error) {
+func (h *Human) SetSecret(_ context.Context, _ secrets.Secret) (secrets.Secret, error) {
 	return nil, errors.New("read only")
 }
 
 // CopySecret fails with an error.
-func (h *Human) CopySecret(_ context.Context, id, location string) (secrets.Secret, error) {
+func (h *Human) CopySecret(_ context.Context, _, _ string) (secrets.Secret, error) {
 	return nil, errors.New("read only")
 }
 
 // MoveSecret fails with an error.
-func (h *Human) MoveSecret(_ context.Context, id, location string) (secrets.Secret, error) {
+func (h *Human) MoveSecret(_ context.Context, _, _ string) (secrets.Secret, error) {
 	return nil, errors.New("read only")
 }
 
 // DeleteSecret fails with an error.
-func (h *Human) DeleteSecret(_ context.Context, id string) error {
+func (h *Human) DeleteSecret(_ context.Context, _ string) error {
 	return errors.New("read only")
 }

--- a/pkg/secrets/human/human.go
+++ b/pkg/secrets/human/human.go
@@ -27,14 +27,14 @@ type Human struct {
 
 var _ secrets.Keeper = &Human{}
 
-// New creates a new human secrets keeper.
+// New creates a new human secret keeper.
 func New() *Human {
 	return &Human{
 		secrets: make(map[string]Question, 1),
 	}
 }
 
-// AddQuestion adds a question to the human secrets keeper.
+// AddQuestion adds a question to the human secret keeper.
 func (h *Human) AddQuestion(
 	id string,
 	askFor []string,

--- a/pkg/secrets/keepass/config.go
+++ b/pkg/secrets/keepass/config.go
@@ -2,6 +2,8 @@ package keepass
 
 import (
 	"context"
+	"fmt"
+	"io"
 	"os"
 	"reflect"
 
@@ -38,6 +40,22 @@ func Builder(_ context.Context, c any) (secrets.Keeper, error) {
 	return NewKeepass(path, cfg.Master)
 }
 
+// Print prints the configuration for the Keepass secret keeper.
+func Print(c any, w io.Writer) error {
+	cfg, isKeepass := c.(*Config)
+	if !isKeepass {
+		return plugin.ErrConfig
+	}
+
+	fmt.Fprintln(w, "path:", cfg.Path)
+	masterVal := "<not set>"
+	if cfg.Master != "" {
+		masterVal = "<hidden>"
+	}
+	fmt.Fprintln(w, "master:", masterVal)
+	return nil
+}
+
 func init() {
 	cmd := plugin.CmdConfig{
 		Short: "Configure a Keepass secret keeper",
@@ -61,5 +79,5 @@ func init() {
 			return kc, nil
 		},
 	}
-	plugin.Register(ConfigType, reflect.TypeOf(Config{}), Builder, nil, cmd)
+	plugin.Register(ConfigType, reflect.TypeOf(Config{}), Builder, nil, Print, cmd)
 }

--- a/pkg/secrets/keepass/keepass.go
+++ b/pkg/secrets/keepass/keepass.go
@@ -95,7 +95,7 @@ func (k *Keepass) reload() error {
 // qualified path.
 func (k *Keepass) ListLocations(ctx context.Context) ([]string, error) {
 	kw := k.Walker(false)
-	locations := []string{}
+	var locations []string
 	for kw.Next() {
 		select {
 		case <-ctx.Done():
@@ -113,7 +113,7 @@ func (k *Keepass) ListSecrets(
 	folder string,
 ) ([]string, error) {
 	kw := k.Walker(true)
-	secrets := []string{}
+	var secs []string
 	for kw.Next() {
 		select {
 		case <-ctx.Done():
@@ -125,11 +125,11 @@ func (k *Keepass) ListSecrets(
 				continue
 			}
 
-			secrets = append(secrets, makeID(e.UUID))
+			secs = append(secs, makeID(e.UUID))
 		}
 	}
 
-	return secrets, nil
+	return secs, nil
 }
 
 // GetSecret retrieves the identified secret from the Keepass database.
@@ -165,7 +165,7 @@ func (k *Keepass) GetSecretsByName(
 	ctx context.Context,
 	name string,
 ) ([]secrets.Secret, error) {
-	secrets := []secrets.Secret{}
+	var secs []secrets.Secret
 	kw := k.Walker(true)
 	for kw.Next() {
 		select {
@@ -176,12 +176,12 @@ func (k *Keepass) GetSecretsByName(
 			dir := kw.Dir()
 
 			if e.GetTitle() == name {
-				secrets = append(secrets, newSecret(k.db, e, dir))
+				secs = append(secs, newSecret(k.db, e, dir))
 			}
 		}
 	}
 
-	return secrets, nil
+	return secs, nil
 }
 
 // getGroup retrieves the named group or returns nil.
@@ -363,7 +363,7 @@ func (k *Keepass) MoveSecret(
 
 // DeleteSecret removes the secret from the Keepass database.
 func (k *Keepass) DeleteSecret(
-	ctx context.Context,
+	_ context.Context,
 	id string,
 ) error {
 	kw := k.Walker(false)

--- a/pkg/secrets/keepass/keepass.go
+++ b/pkg/secrets/keepass/keepass.go
@@ -22,7 +22,7 @@ type Keepass struct {
 var _ secrets.Keeper = &Keepass{}
 
 // NewKeepassNoVerify creates a new Keepass Keeper and returns it. It does not
-// attempt to read the database or verify it is setup correctly.
+// attempt to read the database or verify it is set up correctly.
 func NewKeepassNoVerify(path, master string) (*Keepass, error) {
 	db := keepass.NewDatabase()
 	db.Credentials = keepass.NewPasswordCredentials(master)

--- a/pkg/secrets/keepass/walker.go
+++ b/pkg/secrets/keepass/walker.go
@@ -12,8 +12,8 @@ type groupDir struct {
 	dir   string
 }
 
-// KeepassWalker represents a tool for walking Keepass records.
-type KeepassWalker struct {
+// Walker represents a tool for walking Keepass records.
+type Walker struct {
 	groups  []groupDir
 	entries []*keepass.Entry
 
@@ -25,8 +25,8 @@ type KeepassWalker struct {
 }
 
 // Walker creates an iterator for walking through the Keepass database records.
-func (k *Keepass) Walker(walkEntries bool) *KeepassWalker {
-	w := &KeepassWalker{
+func (k *Keepass) Walker(walkEntries bool) *Walker {
+	w := &Walker{
 		groups: []groupDir{
 			{
 				group: &k.db.Content.Root.Groups[0],
@@ -42,7 +42,7 @@ func (k *Keepass) Walker(walkEntries bool) *KeepassWalker {
 
 // pushGroups pushes a pointer to each group onto the open list in reverse
 // order.
-func (w *KeepassWalker) pushGroups(groups []keepass.Group) {
+func (w *Walker) pushGroups(groups []keepass.Group) {
 	for i := len(groups) - 1; i >= 0; i-- {
 		thisDir := path.Join(w.currentDir, groups[i].Name)
 		w.groups = slices.Push(w.groups, groupDir{&groups[i], thisDir})
@@ -51,7 +51,7 @@ func (w *KeepassWalker) pushGroups(groups []keepass.Group) {
 
 // pushEntries pushes a pointer to each entry onto the open list in reverse
 // order.
-func (w *KeepassWalker) pushEntries(entries []keepass.Entry) {
+func (w *Walker) pushEntries(entries []keepass.Entry) {
 	for i := len(entries) - 1; i >= 0; i-- {
 		w.entries = slices.Push(w.entries, &entries[i])
 	}
@@ -61,7 +61,7 @@ func (w *KeepassWalker) pushEntries(entries []keepass.Entry) {
 // this will return true if another entry is found in the tree. Otherwise, this
 // will return false if another group is found in the tree. Returns false if no
 // records are left for iteration.
-func (w *KeepassWalker) Next() bool {
+func (w *Walker) Next() bool {
 	if w.walkEntries {
 		return w.nextEntry()
 	}
@@ -70,7 +70,7 @@ func (w *KeepassWalker) Next() bool {
 
 // nextEntry sets the cursor on the next available entry. If no such entry is
 // found, this returns false, otherwise returns true.
-func (w *KeepassWalker) nextEntry() bool {
+func (w *Walker) nextEntry() bool {
 	for len(w.entries) == 0 {
 		if len(w.groups) == 0 {
 			return false
@@ -94,7 +94,7 @@ func (w *KeepassWalker) nextEntry() bool {
 
 // nextGroup sets the cursor on the next available group. If no such group is
 // found, this returns false, otherwise returns true.
-func (w *KeepassWalker) nextGroup() bool {
+func (w *Walker) nextGroup() bool {
 	if len(w.groups) == 0 {
 		return false
 	}
@@ -109,16 +109,16 @@ func (w *KeepassWalker) nextGroup() bool {
 }
 
 // Entry retrieves the current entry to inspect during iteration.
-func (w *KeepassWalker) Entry() *keepass.Entry {
+func (w *Walker) Entry() *keepass.Entry {
 	return w.currentEntry
 }
 
 // Group retrieves the current group to inspect during iteration.
-func (w *KeepassWalker) Group() *keepass.Group {
+func (w *Walker) Group() *keepass.Group {
 	return w.currentGroup
 }
 
 // Dir retrieves the name of the location of the current group as a path.
-func (w *KeepassWalker) Dir() string {
+func (w *Walker) Dir() string {
 	return w.currentDir
 }

--- a/pkg/secrets/keeper.go
+++ b/pkg/secrets/keeper.go
@@ -35,7 +35,7 @@ type Keeper interface {
 	GetSecretsByName(ctx context.Context, name string) ([]Secret, error)
 
 	// GetSecret returns a secret by unique ID, which is Keeper dependant. If no
-	// secret is found for the given ID, this function should returned a nil
+	// secret is found for the given ID, this function should return a nil
 	// Secret with ErrNotFound.
 	GetSecret(ctx context.Context, id string) (Secret, error)
 

--- a/pkg/secrets/keyring/config.go
+++ b/pkg/secrets/keyring/config.go
@@ -37,7 +37,7 @@ func Print(c any, w io.Writer) error {
 		return plugin.ErrConfig
 	}
 
-	fmt.Fprintln(w, "service_name:", cfg.ServiceName)
+	fmt.Fprintln(w, "keyring:", cfg.ServiceName)
 	return nil
 }
 

--- a/pkg/secrets/keyring/config.go
+++ b/pkg/secrets/keyring/config.go
@@ -2,6 +2,8 @@ package keyring
 
 import (
 	"context"
+	"fmt"
+	"io"
 	"reflect"
 
 	"github.com/zostay/ghost/pkg/config"
@@ -28,6 +30,17 @@ func Builder(_ context.Context, c any) (secrets.Keeper, error) {
 	return New(cfg.ServiceName), nil
 }
 
+// Print prints the configuration for the keyring secret keeper.
+func Print(c any, w io.Writer) error {
+	cfg, isKeyring := c.(*Config)
+	if !isKeyring {
+		return plugin.ErrConfig
+	}
+
+	fmt.Fprintln(w, "service_name:", cfg.ServiceName)
+	return nil
+}
+
 func init() {
 	cmd := plugin.CmdConfig{
 		Short: "Configure a secret keeper that uses the system keyring",
@@ -46,5 +59,5 @@ func init() {
 			return kc, nil
 		},
 	}
-	plugin.Register(ConfigType, reflect.TypeOf(Config{}), Builder, nil, cmd)
+	plugin.Register(ConfigType, reflect.TypeOf(Config{}), Builder, nil, Print, cmd)
 }

--- a/pkg/secrets/lastpass/config.go
+++ b/pkg/secrets/lastpass/config.go
@@ -2,6 +2,8 @@ package lastpass
 
 import (
 	"context"
+	"fmt"
+	"io"
 	"reflect"
 
 	"github.com/zostay/ghost/pkg/config"
@@ -35,6 +37,22 @@ func Builder(ctx context.Context, c any) (secrets.Keeper, error) {
 	return kpr, nil
 }
 
+// Print prints the configuration for the lastpass secret keeper.
+func Print(c any, w io.Writer) error {
+	cfg, isLastpass := c.(*Config)
+	if !isLastpass {
+		return plugin.ErrConfig
+	}
+
+	fmt.Fprintln(w, "username:", cfg.Username)
+	passwordVal := "<not set>"
+	if cfg.Password != "" {
+		passwordVal = "<hidden>"
+	}
+	fmt.Fprintln(w, "password:", passwordVal)
+	return nil
+}
+
 func init() {
 	cmd := plugin.CmdConfig{
 		Short: "Configure a LastPass secret keeper",
@@ -58,5 +76,5 @@ func init() {
 			return kc, nil
 		},
 	}
-	plugin.Register(ConfigType, reflect.TypeOf(Config{}), Builder, nil, cmd)
+	plugin.Register(ConfigType, reflect.TypeOf(Config{}), Builder, nil, Print, cmd)
 }

--- a/pkg/secrets/lastpass/config.go
+++ b/pkg/secrets/lastpass/config.go
@@ -29,7 +29,7 @@ func Builder(ctx context.Context, c any) (secrets.Keeper, error) {
 		return nil, plugin.ErrConfig
 	}
 
-	kpr, err := NewLastPass(ctx, cfg.Username, cfg.Password)
+	kpr, err := New(ctx, cfg.Username, cfg.Password)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/secrets/lastpass/lastpass.go
+++ b/pkg/secrets/lastpass/lastpass.go
@@ -15,10 +15,10 @@ import (
 
 var ErrTooManyRetries = errors.New("too many retries")
 
-// LastPassClient defines the interface required for a LastPass client.
+// Client defines the interface required for a LastPass client.
 // Normally, this is fulfilled by lastpass.Client, but is handled as an
 // interface to make testing possible without an actual LastPass account.
-type LastPassClient interface {
+type Client interface {
 	// Accounts should list secrets.
 	Accounts(ctx context.Context) ([]*lastpass.Account, error)
 
@@ -62,7 +62,7 @@ func _retry[T any](run func() (T, error)) (t T, err error) {
 // LastPass is a secret Keeper that gets secrets from the LastPass
 // password manager service.
 type LastPass struct {
-	lp LastPassClient
+	lp Client
 }
 
 var _ secrets.Keeper = &LastPass{}
@@ -70,7 +70,7 @@ var _ secrets.Keeper = &LastPass{}
 // NewLastPassWithClient constructs a new LastPass Keeper with a custom LastPass
 // client. This constructor is mostly intended for use during testing.
 func NewLastPassWithClient(
-	lp LastPassClient,
+	lp Client,
 ) (*LastPass, error) {
 	return &LastPass{lp}, nil
 }

--- a/pkg/secrets/lastpass/lastpass.go
+++ b/pkg/secrets/lastpass/lastpass.go
@@ -243,7 +243,7 @@ func (l *LastPass) CopySecret(
 
 	newSec := newSecret(a)
 	newSec.Account.ID = ""
-	newSec.Account.Group = grp
+	newSec.Group = grp
 	return newSec, l.updateAccount(ctx, newSec.Account)
 }
 
@@ -258,6 +258,6 @@ func (l *LastPass) MoveSecret(
 	}
 
 	newSec := newSecret(a)
-	newSec.Account.Group = grp
+	newSec.Group = grp
 	return newSec, l.updateAccount(ctx, newSec.Account)
 }

--- a/pkg/secrets/lastpass/lastpass.go
+++ b/pkg/secrets/lastpass/lastpass.go
@@ -13,8 +13,6 @@ import (
 	"github.com/zostay/ghost/pkg/secrets"
 )
 
-var ErrTooManyRetries = errors.New("too many retries")
-
 // Client defines the interface required for a LastPass client.
 // Normally, this is fulfilled by lastpass.Client, but is handled as an
 // interface to make testing possible without an actual LastPass account.
@@ -67,19 +65,19 @@ type LastPass struct {
 
 var _ secrets.Keeper = &LastPass{}
 
-// NewLastPassWithClient constructs a new LastPass Keeper with a custom LastPass
+// NewWithCLient constructs a new LastPass Keeper with a custom LastPass
 // client. This constructor is mostly intended for use during testing.
-func NewLastPassWithClient(
+func NewWithCLient(
 	lp Client,
 ) (*LastPass, error) {
 	return &LastPass{lp}, nil
 }
 
-// NewLastPass constructs and returns a new LastPass Keeper or returns an error
+// New constructs and returns a new LastPass Keeper or returns an error
 // if there was a problem during construction.
 //
 // The username and password arguments are used to authenticate with LastPass.
-func NewLastPass(ctx context.Context, username, password string) (*LastPass, error) {
+func New(ctx context.Context, username, password string) (*LastPass, error) {
 	lp, err := lastpass.NewClient(ctx, username, password)
 	if err != nil {
 		return nil, err
@@ -116,14 +114,14 @@ func (l *LastPass) ListSecrets(ctx context.Context, location string) ([]string, 
 		return nil, err
 	}
 
-	secrets := make([]string, 0, len(as))
+	secs := make([]string, 0, len(as))
 	for _, a := range as {
 		if a.Group == location {
-			secrets = append(secrets, a.ID)
+			secs = append(secs, a.ID)
 		}
 	}
 
-	return secrets, nil
+	return secs, nil
 }
 
 func (l *LastPass) getAccount(
@@ -165,14 +163,14 @@ func (l *LastPass) GetSecretsByName(
 		return nil, err
 	}
 
-	secrets := []secrets.Secret{}
+	var secs []secrets.Secret
 	for _, a := range as {
 		if a.Name == name {
-			secrets = append(secrets, newSecret(a))
+			secs = append(secs, newSecret(a))
 		}
 	}
 
-	return secrets, nil
+	return secs, nil
 }
 
 func (l *LastPass) addAccount(ctx context.Context, acc *lastpass.Account) error {

--- a/pkg/secrets/lastpass/lastpass_test.go
+++ b/pkg/secrets/lastpass/lastpass_test.go
@@ -57,7 +57,7 @@ func TestLastPass(t *testing.T) {
 	t.Parallel()
 
 	factory := func() (secrets.Keeper, error) {
-		return lastpass.NewLastPassWithClient(newTestLastPass())
+		return lastpass.NewWithCLient(newTestLastPass())
 	}
 
 	ts := keepertest.New(factory)

--- a/pkg/secrets/lastpass/secret.go
+++ b/pkg/secrets/lastpass/secret.go
@@ -82,18 +82,18 @@ func (s *Secret) SetPassword(secret string) {
 
 // Url returns the LastPass account URL.
 func (s *Secret) Url() *url.URL {
-	u, _ := url.Parse(s.Account.URL)
+	u, _ := url.Parse(s.URL)
 	return u
 }
 
 // SetUrl sets the LastPass account URL.
 func (s *Secret) SetUrl(url *url.URL) {
-	s.Account.URL = url.String()
+	s.URL = url.String()
 }
 
 // Location returns the LastPass account Group.
 func (s *Secret) Location() string {
-	return s.Account.Group
+	return s.Group
 }
 
 func (s *Secret) parseNotes() {
@@ -101,10 +101,10 @@ func (s *Secret) parseNotes() {
 		return
 	}
 
-	flds := parseNotes(s.Account.Notes)
+	flds := parseNotes(s.Notes)
 	if flds == nil {
 		s.notes = map[string]string{
-			"Notes": s.Account.Notes,
+			"Notes": s.Notes,
 		}
 	}
 
@@ -152,6 +152,6 @@ func (s *Secret) SetField(name, value string) {
 
 // LastModified returns the LastPass account LastModifiedGMT.
 func (s *Secret) LastModified() time.Time {
-	lmSeconds, _ := strconv.ParseInt(s.Account.LastModifiedGMT, 10, 64)
+	lmSeconds, _ := strconv.ParseInt(s.LastModifiedGMT, 10, 64)
 	return time.Unix(lmSeconds, 0)
 }

--- a/pkg/secrets/lastpass/secret.go
+++ b/pkg/secrets/lastpass/secret.go
@@ -82,8 +82,8 @@ func (s *Secret) SetPassword(secret string) {
 
 // Url returns the LastPass account URL.
 func (s *Secret) Url() *url.URL {
-	url, _ := url.Parse(s.Account.URL)
-	return url
+	u, _ := url.Parse(s.Account.URL)
+	return u
 }
 
 // SetUrl sets the LastPass account URL.

--- a/pkg/secrets/low/config.go
+++ b/pkg/secrets/low/config.go
@@ -35,7 +35,7 @@ func Builder(_ context.Context, c any) (secrets.Keeper, error) {
 		return nil, err
 	}
 
-	return NewLowSecurity(path), nil
+	return NewSecurity(path), nil
 }
 
 // Print prints the configuration for the low-security secret keeper.

--- a/pkg/secrets/low/config.go
+++ b/pkg/secrets/low/config.go
@@ -2,6 +2,8 @@ package low
 
 import (
 	"context"
+	"fmt"
+	"io"
 	"os"
 	"reflect"
 
@@ -36,6 +38,17 @@ func Builder(_ context.Context, c any) (secrets.Keeper, error) {
 	return NewLowSecurity(path), nil
 }
 
+// Print prints the configuration for the low-security secret keeper.
+func Print(c any, w io.Writer) error {
+	cfg, isLow := c.(*Config)
+	if !isLow {
+		return plugin.ErrConfig
+	}
+
+	fmt.Fprintln(w, "path:", cfg.Path)
+	return nil
+}
+
 func init() {
 	cmd := plugin.CmdConfig{
 		Short: "Configure a low-security secret keeper",
@@ -54,5 +67,5 @@ func init() {
 			return kc, nil
 		},
 	}
-	plugin.Register(ConfigType, reflect.TypeOf(Config{}), Builder, nil, cmd)
+	plugin.Register(ConfigType, reflect.TypeOf(Config{}), Builder, nil, Print, cmd)
 }

--- a/pkg/secrets/low/low.go
+++ b/pkg/secrets/low/low.go
@@ -18,26 +18,26 @@ import (
 // supported.
 var ErrUnsupportedVersion = errors.New("unsupported low security file version")
 
-// LowSecurity is a secret keeper for storing secrets in plain text. Only
+// Security is a secret keeper for storing secrets in plain text. Only
 // suitable for very low value secrets.
-type LowSecurity struct {
+type Security struct {
 	// LoaderSaver is the loader/saver to use for the secrets.
 	fssafe.LoaderSaver
 }
 
-var _ secrets.Keeper = &LowSecurity{}
+var _ secrets.Keeper = &Security{}
 
-// NewLowSecurity creates a new low security secret keeper at the given path.
-func NewLowSecurity(path string) *LowSecurity {
-	return &LowSecurity{
+// NewSecurity creates a new low security secret keeper at the given path.
+func NewSecurity(path string) *Security {
+	return &Security{
 		LoaderSaver: fssafe.NewFileSystemLoaderSaver(path),
 	}
 }
 
-// NewLowSecurityCustom creates a new low security secret keeper with the given
+// NewSecurityCustom creates a new low security secret keeper with the given
 // loader/saver.
-func NewLowSecurityCustom(ls fssafe.LoaderSaver) *LowSecurity {
-	return &LowSecurity{
+func NewSecurityCustom(ls fssafe.LoaderSaver) *Security {
+	return &Security{
 		LoaderSaver: ls,
 	}
 }
@@ -47,7 +47,7 @@ func makeID() string {
 }
 
 // loadSecrets loads the secrets from file.
-func (s *LowSecurity) loadSecrets() (*lowSecurityConfig, error) {
+func (s *Security) loadSecrets() (*lowSecurityConfig, error) {
 	r, err := s.Loader()
 	if err != nil {
 		// give saving a try first
@@ -82,7 +82,7 @@ func (s *LowSecurity) loadSecrets() (*lowSecurityConfig, error) {
 }
 
 // saveSecrets saves the secrets to file.
-func (s *LowSecurity) saveSecrets(cfg *lowSecurityConfig) error {
+func (s *Security) saveSecrets(cfg *lowSecurityConfig) error {
 	w, err := s.Saver()
 	if err != nil {
 		return err
@@ -103,7 +103,7 @@ func (s *LowSecurity) saveSecrets(cfg *lowSecurityConfig) error {
 }
 
 // ListLocations returns all the locations listed in the low security file.
-func (s *LowSecurity) ListLocations(context.Context) ([]string, error) {
+func (s *Security) ListLocations(context.Context) ([]string, error) {
 	cfg, err := s.loadSecrets()
 	if err != nil {
 		return nil, err
@@ -120,8 +120,8 @@ func (s *LowSecurity) ListLocations(context.Context) ([]string, error) {
 
 // ListSecrets returns all the secrets listed in the low security file for the
 // given location.
-func (s *LowSecurity) ListSecrets(
-	ctx context.Context,
+func (s *Security) ListSecrets(
+	_ context.Context,
 	location string,
 ) ([]string, error) {
 	cfg, err := s.loadSecrets()
@@ -142,8 +142,8 @@ func (s *LowSecurity) ListSecrets(
 }
 
 // GetSecret returns the secret with the given ID from the low security file.
-func (s *LowSecurity) GetSecret(
-	ctx context.Context,
+func (s *Security) GetSecret(
+	_ context.Context,
 	id string,
 ) (secrets.Secret, error) {
 	cfg, err := s.loadSecrets()
@@ -161,8 +161,8 @@ func (s *LowSecurity) GetSecret(
 
 // GetSecretsByName returns all the secrets with the given name from the low
 // security file.
-func (s *LowSecurity) GetSecretsByName(
-	ctx context.Context,
+func (s *Security) GetSecretsByName(
+	_ context.Context,
 	name string,
 ) ([]secrets.Secret, error) {
 	cfg, err := s.loadSecrets()
@@ -185,8 +185,8 @@ func (s *LowSecurity) GetSecretsByName(
 }
 
 // SetSecret sets the secret with the given ID in the low security file.
-func (s *LowSecurity) SetSecret(
-	ctx context.Context,
+func (s *Security) SetSecret(
+	_ context.Context,
 	secret secrets.Secret,
 ) (secrets.Secret, error) {
 	cfg, err := s.loadSecrets()
@@ -210,8 +210,8 @@ func (s *LowSecurity) SetSecret(
 
 // DeleteSecret deletes the secret with the given ID from the low security
 // file.
-func (s *LowSecurity) DeleteSecret(
-	ctx context.Context,
+func (s *Security) DeleteSecret(
+	_ context.Context,
 	id string,
 ) error {
 	cfg, err := s.loadSecrets()
@@ -231,8 +231,8 @@ func (s *LowSecurity) DeleteSecret(
 
 // CopySecret copies the secret with the given ID from the low security file
 // to the given location.
-func (s *LowSecurity) CopySecret(
-	ctx context.Context,
+func (s *Security) CopySecret(
+	_ context.Context,
 	id string,
 	location string,
 ) (secrets.Secret, error) {
@@ -259,8 +259,8 @@ func (s *LowSecurity) CopySecret(
 }
 
 // MoveSecret moves the secre to a new location.
-func (s *LowSecurity) MoveSecret(
-	ctx context.Context,
+func (s *Security) MoveSecret(
+	_ context.Context,
 	id string,
 	location string,
 ) (secrets.Secret, error) {

--- a/pkg/secrets/low/low_test.go
+++ b/pkg/secrets/low/low_test.go
@@ -14,7 +14,7 @@ func TestLowSecurity(t *testing.T) {
 	t.Parallel()
 
 	factory := func() (secrets.Keeper, error) {
-		return low.NewLowSecurityCustom(fssafe.NewTestingLoaderSaver()), nil
+		return low.NewSecurityCustom(fssafe.NewTestingLoaderSaver()), nil
 	}
 
 	ts := keepertest.New(factory)

--- a/pkg/secrets/low/secret.go
+++ b/pkg/secrets/low/secret.go
@@ -91,11 +91,11 @@ func (s *Secret) UnmarshalYAML(node *yaml.Node) error {
 		case "Location":
 			s.Single.SetLocation(node.Content[i+1].Value)
 		case "URL":
-			url, err := url.Parse(node.Content[i+1].Value)
+			u, err := url.Parse(node.Content[i+1].Value)
 			if err != nil {
 				return err
 			}
-			s.Single.SetUrl(url)
+			s.Single.SetUrl(u)
 		case "LastModified":
 			us, err := strconv.ParseInt(node.Content[i+1].Value, 10, 64)
 			if err != nil {

--- a/pkg/secrets/low/secret.go
+++ b/pkg/secrets/low/secret.go
@@ -37,19 +37,19 @@ func (s *Secret) SetID(id string) {
 
 // MarshalYAML marshals the secret to YAML.
 func (s *Secret) MarshalYAML() (interface{}, error) {
-	lm := s.Single.LastModified()
+	lm := s.LastModified()
 	if lm.IsZero() {
 		lm = time.Now()
 	}
 
 	return map[string]any{
-		"Name":         s.Single.Name(),
-		"Username":     s.Single.Username(),
-		"Password":     s.Single.Password(),
-		"Type":         s.Single.Type(),
-		"Location":     s.Single.Location(),
+		"Name":         s.Name(),
+		"Username":     s.Username(),
+		"Password":     s.Password(),
+		"Type":         s.Type(),
+		"Location":     s.Location(),
 		"URL":          secrets.UrlString(s),
-		"Fields":       s.Single.Fields(),
+		"Fields":       s.Fields(),
 		"LastModified": lm.Unix(),
 	}, nil
 }
@@ -71,7 +71,7 @@ func (s *Secret) UnmarshalYAML(node *yaml.Node) error {
 			for j := 0; j < len(fNode.Content); j += 2 {
 				key := fNode.Content[j].Value
 				val := fNode.Content[j+1].Value
-				s.Single.SetField(key, val)
+				s.SetField(key, val)
 			}
 		}
 
@@ -81,27 +81,27 @@ func (s *Secret) UnmarshalYAML(node *yaml.Node) error {
 
 		switch node.Content[i].Value {
 		case "Name":
-			s.Single.SetName(node.Content[i+1].Value)
+			s.SetName(node.Content[i+1].Value)
 		case "Username":
-			s.Single.SetUsername(node.Content[i+1].Value)
+			s.SetUsername(node.Content[i+1].Value)
 		case "Password":
-			s.Single.SetPassword(node.Content[i+1].Value)
+			s.SetPassword(node.Content[i+1].Value)
 		case "Type":
-			s.Single.SetType(node.Content[i+1].Value)
+			s.SetType(node.Content[i+1].Value)
 		case "Location":
-			s.Single.SetLocation(node.Content[i+1].Value)
+			s.SetLocation(node.Content[i+1].Value)
 		case "URL":
 			u, err := url.Parse(node.Content[i+1].Value)
 			if err != nil {
 				return err
 			}
-			s.Single.SetUrl(u)
+			s.SetUrl(u)
 		case "LastModified":
 			us, err := strconv.ParseInt(node.Content[i+1].Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			s.Single.SetLastModified(time.Unix(us, 0))
+			s.SetLastModified(time.Unix(us, 0))
 		}
 	}
 

--- a/pkg/secrets/memory/config.go
+++ b/pkg/secrets/memory/config.go
@@ -32,5 +32,5 @@ func init() {
 			return config.KeeperConfig{"type": ConfigType}, nil
 		},
 	}
-	plugin.Register(ConfigType, reflect.TypeOf(Config{}), Builder, nil, cmd)
+	plugin.Register(ConfigType, reflect.TypeOf(Config{}), Builder, nil, nil, cmd)
 }

--- a/pkg/secrets/memory/memory.go
+++ b/pkg/secrets/memory/memory.go
@@ -24,15 +24,6 @@ type Memory struct {
 
 var _ secrets.Keeper = &Memory{}
 
-// MustNew calls New and panics if it returns an error.
-func MustNew() *Memory {
-	i, err := New()
-	if err != nil {
-		panic(err)
-	}
-	return i
-}
-
 // New constructs a new secret memory store.
 func New() (*Memory, error) {
 	k := make([]byte, 32)

--- a/pkg/secrets/modifier.go
+++ b/pkg/secrets/modifier.go
@@ -207,23 +207,6 @@ func SetField(secret Secret, name, value string) Secret {
 	return &modifier{base: secret, fields: map[string]string{name: value}}
 }
 
-func RemoveField(secret Secret, name string) Secret {
-	if mod, isMod := secret.(SettableFields); isMod {
-		mod.DeleteField(name)
-		return secret
-	}
-
-	return &modifier{base: secret, removeFields: set.New(name)}
-}
-
-func SetLastModified(secret Secret, lastModified time.Time) Secret {
-	if mod, isMod := secret.(SettableLastModified); isMod {
-		mod.SetLastModified(lastModified)
-		return secret
-	}
-	return &modifier{base: secret, lastModified: &lastModified}
-}
-
 func SetUrl(secret Secret, url *url.URL) Secret {
 	if mod, isMod := secret.(SettableUrl); isMod {
 		mod.SetUrl(url)

--- a/pkg/secrets/onepassword/config.go
+++ b/pkg/secrets/onepassword/config.go
@@ -2,6 +2,8 @@ package onepassword
 
 import (
 	"context"
+	"fmt"
+	"io"
 	"reflect"
 
 	"github.com/zostay/ghost/pkg/config"
@@ -33,6 +35,22 @@ func Builder(ctx context.Context, c any) (secrets.Keeper, error) {
 	return kpr, nil
 }
 
+// Print prints the configuration for the 1password secret keeper.
+func Print(c any, w io.Writer) error {
+	cfg, is1password := c.(*Config)
+	if !is1password {
+		return plugin.ErrConfig
+	}
+
+	fmt.Fprintln(w, "connect host:", cfg.ConnectHost)
+	tokenVal := "<not set>"
+	if cfg.ConnectToken != "" {
+		tokenVal = "<hidden>"
+	}
+	fmt.Fprintln(w, "connect token:", tokenVal)
+	return nil
+}
+
 func init() {
 	cmd := plugin.CmdConfig{
 		Short: "Configure a 1Password secret keeper (requires a Connect Server)",
@@ -56,5 +74,5 @@ func init() {
 			return kc, nil
 		},
 	}
-	plugin.Register(ConfigType, reflect.TypeOf(Config{}), Builder, nil, cmd)
+	plugin.Register(ConfigType, reflect.TypeOf(Config{}), Builder, nil, Print, cmd)
 }

--- a/pkg/secrets/onepassword/config.go
+++ b/pkg/secrets/onepassword/config.go
@@ -24,7 +24,7 @@ type Config struct {
 }
 
 // Builder builds a new 1password secret keeper.
-func Builder(ctx context.Context, c any) (secrets.Keeper, error) {
+func Builder(_ context.Context, c any) (secrets.Keeper, error) {
 	cfg, is1password := c.(*Config)
 	if !is1password {
 		return nil, plugin.ErrConfig

--- a/pkg/secrets/onepassword/onepassword.go
+++ b/pkg/secrets/onepassword/onepassword.go
@@ -18,17 +18,6 @@ func NewOnePassword(url string, token string) *OnePassword {
 	}
 }
 
-func NewOnePasswordFromEnvironment() (*OnePassword, error) {
-	op, err := connect.NewClientFromEnvironment()
-	if err != nil {
-		return nil, err
-	}
-
-	return &OnePassword{
-		pc: op,
-	}, nil
-}
-
 func (o *OnePassword) ListLocations(_ context.Context) ([]string, error) {
 	vs, err := o.pc.GetVaults()
 	if err != nil {
@@ -49,12 +38,12 @@ func (o *OnePassword) ListSecrets(_ context.Context, location string) ([]string,
 		return nil, err
 	}
 
-	secrets := make([]string, 0, len(is))
+	secs := make([]string, 0, len(is))
 	for _, i := range is {
-		secrets = append(secrets, i.ID)
+		secs = append(secs, i.ID)
 	}
 
-	return secrets, nil
+	return secs, nil
 }
 
 func (o *OnePassword) GetSecretsByName(_ context.Context, name string) ([]secrets.Secret, error) {
@@ -63,7 +52,7 @@ func (o *OnePassword) GetSecretsByName(_ context.Context, name string) ([]secret
 		return nil, err
 	}
 
-	var secrets []secrets.Secret
+	var secs []secrets.Secret
 	for _, v := range vs {
 		is, err := o.pc.GetItemsByTitle(name, v.ID)
 		if err != nil {
@@ -71,11 +60,11 @@ func (o *OnePassword) GetSecretsByName(_ context.Context, name string) ([]secret
 		}
 
 		for idx := range is {
-			secrets = append(secrets, newSecret(&is[idx]))
+			secs = append(secs, newSecret(&is[idx]))
 		}
 	}
 
-	return secrets, nil
+	return secs, nil
 }
 
 func (o *OnePassword) GetSecret(_ context.Context, id string) (secrets.Secret, error) {

--- a/pkg/secrets/onepassword/secret.go
+++ b/pkg/secrets/onepassword/secret.go
@@ -168,7 +168,7 @@ func (s *Single) Type() string {
 	return ""
 }
 
-func (s *Single) SetType(typ string) {}
+func (s *Single) SetType(_ string) {}
 
 func (s *Single) Fields() map[string]string {
 	flds := make(map[string]string, len(s.item.Fields))

--- a/pkg/secrets/policy/matchrule.go
+++ b/pkg/secrets/policy/matchrule.go
@@ -17,10 +17,13 @@ func (mr MatchRule) matchLocationAndAcceptable(loc string) matchStatus {
 		return matchMiss
 	}
 
-	if mr.acceptance == Allow {
+	switch mr.acceptance {
+	case Allow:
 		return matchYes
-	} else if mr.acceptance == InheritAcceptance {
+	case InheritAcceptance:
 		return matchMiss
+	case Deny:
+		return matchNo
 	}
 	return matchNo
 }

--- a/pkg/secrets/policy/policy.go
+++ b/pkg/secrets/policy/policy.go
@@ -128,10 +128,12 @@ Loc:
 func (p *Policy) accessibleSecret(sec secrets.Secret) bool {
 	for _, r := range p.matchRule {
 		m := r.matchSecretAndAccessible(p.defaultRule, sec)
-		if m == matchYes {
+		switch m {
+		case matchYes:
 			return true
-		} else if m == matchNo {
+		case matchNo:
 			return false
+		case matchMiss:
 		}
 	}
 

--- a/pkg/secrets/policy/rule.go
+++ b/pkg/secrets/policy/rule.go
@@ -16,7 +16,7 @@ type Rule struct {
 	acceptance Acceptance
 }
 
-// NewRule creates a new rule with the given lifetime and inherit acceptance.
+// NewLifetimeRule creates a new rule with the given lifetime and inherit acceptance.
 func NewLifetimeRule(l time.Duration) *Rule {
 	return &Rule{
 		lifetime:   l,

--- a/pkg/secrets/router/config.go
+++ b/pkg/secrets/router/config.go
@@ -68,13 +68,13 @@ func Builder(ctx context.Context, c any) (secrets.Keeper, error) {
 
 	r := NewRouter(defaultKeeper)
 	for _, rt := range cfg.Routes {
-		keeper, err := keeper.Build(ctx, rt.Keeper)
+		kpr, err := keeper.Build(ctx, rt.Keeper)
 		if err != nil {
 			locs := strings.Join(rt.Locations, ",")
 			return nil, fmt.Errorf("unable to build the secret keeper named %q for the route to %q: %w", rt.Keeper, locs, err)
 		}
 
-		err = r.AddKeeper(keeper, rt.Locations...)
+		err = r.AddKeeper(kpr, rt.Locations...)
 		if err != nil {
 			locs := strings.Join(rt.Locations, ",")
 			return nil, fmt.Errorf("unable to add a route for the secret keeper named %q for the route to %q: %w", rt.Keeper, locs, err)
@@ -213,7 +213,7 @@ func RemoveLocationsAndRoutes(rc config.KeeperConfig, removeLocations ...string)
 	routes := rc["routes"].([]map[string]any)
 	removeSet := set.New(removeLocations...)
 
-	deleteRoutes := []int{}
+	var deleteRoutes []int
 	for i, r := range routes {
 		locations := r["locations"].([]any)
 		for _, loc := range locations {

--- a/pkg/secrets/router/config.go
+++ b/pkg/secrets/router/config.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"reflect"
 	"sort"
 	"strings"
@@ -35,6 +36,22 @@ type RouteConfig struct {
 	Locations []string `mapstructure:"locations" yaml:"locations"`
 	// Keeper is the name of the keeper to use for the route.
 	Keeper string `mapstructure:"keeper" yaml:"keeper"`
+}
+
+// Print prints the configuration for the router secret keeper.
+func Print(c any, w io.Writer) error {
+	cfg, isRouter := c.(*Config)
+	if !isRouter {
+		return plugin.ErrConfig
+	}
+
+	fmt.Fprintln(w, "default route:", cfg.DefaultRoute)
+	fmt.Fprintln(w, "routers:")
+	for _, r := range cfg.Routes {
+		fmt.Fprintln(w, "- locations:", strings.Join(r.Locations, ","))
+		fmt.Fprintln(w, "  keeper:", r.Keeper)
+	}
+	return nil
 }
 
 // Builder constructs a new router secret keeper.
@@ -151,7 +168,7 @@ func init() {
 			return kc, nil
 		},
 	}
-	plugin.Register(ConfigType, reflect.TypeOf(Config{}), Builder, Validator, cmd)
+	plugin.Register(ConfigType, reflect.TypeOf(Config{}), Builder, Validator, Print, cmd)
 }
 
 // AddRoute adds a route to the router configuration.

--- a/pkg/secrets/router/router.go
+++ b/pkg/secrets/router/router.go
@@ -217,6 +217,14 @@ func (r *Router) findSecretMatchingId(
 		}
 	}
 
+	if keeper == nil {
+		return "", nil, nil, fmt.Errorf("unknown keeper ID: %s", keeperId)
+	}
+
+	if locations == nil {
+		return "", nil, nil, fmt.Errorf("unknown locations for keeper ID: %s", keeperId)
+	}
+
 	secret, err := keeper.GetSecret(ctx, secretId)
 	if err != nil {
 		return "", nil, nil, err
@@ -262,7 +270,7 @@ func (r *Router) GetSecretsByName(
 	ctx context.Context,
 	name string,
 ) ([]secrets.Secret, error) {
-	foundSecs := []secrets.Secret{}
+	var foundSecs []secrets.Secret
 	err := r.forEachSecret(ctx,
 		func(secret secrets.Secret) error {
 			if secret.Name() == name {

--- a/pkg/secrets/secret.go
+++ b/pkg/secrets/secret.go
@@ -49,15 +49,6 @@ func WithField(name, value string) SingleOption {
 	})
 }
 
-// WithFields sets the given fields on the secret.
-func WithFields(fields map[string]string) SingleOption {
-	return option(func(s *Single) {
-		for name, value := range fields {
-			s.fields[name] = value
-		}
-	})
-}
-
 // WithID sets the ID of the secret, which is useful when copying a secret using
 // NewSingleFromSecret or when initializing a secret with a known ID using
 // NewSecret.

--- a/pkg/secrets/secret.go
+++ b/pkg/secrets/secret.go
@@ -122,7 +122,7 @@ func NewSecret(name, username, password string, opts ...SingleOption) *Single {
 	return sec
 }
 
-// NewSecretFromSecret creates a *Single from the given secret with the
+// NewSingleFromSecret creates a *Single from the given secret with the
 // requested modifications applied.
 func NewSingleFromSecret(s Secret, opts ...SingleOption) *Single {
 	sec := &Single{
@@ -171,12 +171,12 @@ func (s *Single) SetUsername(username string) {
 	s.username = username
 }
 
-// Single returns the secret of the secret.
+// Password returns the secret of the secret.
 func (s *Single) Password() string {
 	return s.password
 }
 
-// SetSecret sets the secret of the secret.
+// SetPassword sets the secret of the secret.
 func (s *Single) SetPassword(password string) {
 	s.password = password
 }

--- a/pkg/secrets/seq/config.go
+++ b/pkg/secrets/seq/config.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"reflect"
 
 	"github.com/spf13/pflag"
@@ -22,6 +23,20 @@ const ConfigType = "seq"
 type Config struct {
 	// Keepers is the list of keepers to use for the seq keeper.
 	Keepers []string `mapstructure:"keepers" yaml:"keepers"`
+}
+
+// Print prints the configuration for the seq secret keeper.
+func Print(c any, w io.Writer) error {
+	cfg, isSeq := c.(*Config)
+	if !isSeq {
+		return plugin.ErrConfig
+	}
+
+	fmt.Fprintln(w, "keepers:")
+	for _, k := range cfg.Keepers {
+		fmt.Fprintln(w, "-", k)
+	}
+	return nil
 }
 
 // Builder constructs a new seq secret keeper.
@@ -127,5 +142,5 @@ func init() {
 			return kc, nil
 		},
 	}
-	plugin.Register(ConfigType, reflect.TypeOf(Config{}), Builder, Validator, cmd)
+	plugin.Register(ConfigType, reflect.TypeOf(Config{}), Builder, Validator, Print, cmd)
 }

--- a/pkg/secrets/seq/seq.go
+++ b/pkg/secrets/seq/seq.go
@@ -48,17 +48,17 @@ func (s *Seq) ListSecrets(
 	ctx context.Context,
 	location string,
 ) ([]string, error) {
-	secrets := set.New[string]()
+	secSet := set.New[string]()
 	for _, k := range s.keepers {
 		secs, err := k.ListSecrets(ctx, location)
 		if err != nil {
 			return nil, err
 		}
 		for _, sec := range secs {
-			secrets.Insert(sec)
+			secSet.Insert(sec)
 		}
 	}
-	return secrets.Keys(), nil
+	return secSet.Keys(), nil
 }
 
 // GetSecret returns the secret from the first Keeper that returns it.
@@ -84,15 +84,15 @@ func (s *Seq) GetSecretsByName(
 	ctx context.Context,
 	name string,
 ) ([]secrets.Secret, error) {
-	secrets := make([]secrets.Secret, 0, 1)
+	allSecs := make([]secrets.Secret, 0, 1)
 	for _, k := range s.keepers {
 		secs, err := k.GetSecretsByName(ctx, name)
 		if err != nil {
 			return nil, err
 		}
-		secrets = append(secrets, secs...)
+		allSecs = append(allSecs, secs...)
 	}
-	return secrets, nil
+	return allSecs, nil
 }
 
 // SetSecret stores the secret in the first Keeper.


### PR DESCRIPTION
This pull request introduces several updates to the configuration and printing functionalities for various secret keepers in the project. The key changes include updating dependencies, adding new configuration printing functions, and modifying the `plugin` package to support these new functions.

### Dependency Updates:
* Updated `golangci-lint-action` from v6 to v7 and its version from v1.59 to v2.0 in `.github/workflows/test.yaml`.
* Added `github.com/pborman/indent` v1.2.1 to `go.mod`.

### Configuration Printing:
* Introduced `PrintConfigFunc` in `pkg/plugin/config.go` to summarize keeper configurations.
* Registered new `PrintConfigFunc` implementations for various keepers including `cache`, `human`, `keepass`, `keyring`, `lastpass`, and `low`. [[1]](diffhunk://#diff-48e0e206fc244e9b599bbcff130531a8b15279cced5c2095cec39484ebe921c7R63-R74) [[2]](diffhunk://#diff-98a62e1207ece3c44c9a7922d9af0279a2f002d8dc56b973a59e4e1c4657445dR93-R113) [[3]](diffhunk://#diff-4729d49089d311ef4268a2c910a55123ffd2e1afbb74301f666f2926d4c5fe07R43-R58) [[4]](diffhunk://#diff-88c10a284ee7a9cc391ab90cf348fbf5dd831036633b59a7e9dc3bec9cd924f2R33-R43) [[5]](diffhunk://#diff-5deed078d3e9161796ae42510b743e03649edee9e7cbddb53f58cdc17f516211R40-R55) [[6]](diffhunk://#diff-47bd8d08fc1cc223c9d62ba38222ef4cc58dab115d20eca5be10bb4c230ead15R41-R51)

### Plugin Package Modifications:
* Modified `plugin.Register` to accept the new `PrintConfigFunc` parameter.
* Updated existing keeper registrations to include the new `PrintConfigFunc`. [[1]](diffhunk://#diff-48e0e206fc244e9b599bbcff130531a8b15279cced5c2095cec39484ebe921c7L89-R102) [[2]](diffhunk://#diff-98a62e1207ece3c44c9a7922d9af0279a2f002d8dc56b973a59e4e1c4657445dL156-R178) [[3]](diffhunk://#diff-4729d49089d311ef4268a2c910a55123ffd2e1afbb74301f666f2926d4c5fe07L64-R82) [[4]](diffhunk://#diff-88c10a284ee7a9cc391ab90cf348fbf5dd831036633b59a7e9dc3bec9cd924f2L49-R62) [[5]](diffhunk://#diff-5deed078d3e9161796ae42510b743e03649edee9e7cbddb53f58cdc17f516211L61-R79) [[6]](diffhunk://#diff-47bd8d08fc1cc223c9d62ba38222ef4cc58dab115d20eca5be10bb4c230ead15R41-R51)

### Configuration File Changes:
* Updated `.golangci.yaml` to version 2, modified enabled linters, and updated linter settings. [[1]](diffhunk://#diff-9917ddc9f1c3304218f7269265b746d997c5c0615478177b5fceecd33ef47cb5L1-L21) [[2]](diffhunk://#diff-9917ddc9f1c3304218f7269265b746d997c5c0615478177b5fceecd33ef47cb5L31-R30) [[3]](diffhunk://#diff-9917ddc9f1c3304218f7269265b746d997c5c0615478177b5fceecd33ef47cb5L57-R74)

### Documentation:
* Added a new section in `Changes.md` to document the configuration printing fixes for `config get` and `config list` commands.

These changes aim to improve the maintainability and clarity of the configuration for secret keepers, as well as ensure that configurations are printed correctly and consistently.